### PR TITLE
Support throwing closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ let foo = Foo(bar: 2, baz: 3.0, qux: "xyz")
 let (bar, qux) = foo => { ($0.bar, $0.qux) }
 ```
 
+It is possible to `throw` errors in a closure passed to `=>` because `=>` is marked with `rethrows`.
+
+```swift
+do {
+    try foo => { try throwable($0) }
+} catch {
+    XCTFail()
+}
+```
+
 ## Lisence
 
 MIT

--- a/Sources/Swiflet.swift
+++ b/Sources/Swiflet.swift
@@ -1,5 +1,5 @@
 infix operator =>
 
-public func =><T, U>(lhs: T, rhs: (T) -> U) -> U {
-    return rhs(lhs)
+public func =><T, U>(lhs: T, rhs: (T) throws -> U) rethrows -> U {
+    return try rhs(lhs)
 }

--- a/Tests/SwifletTests/SwifletTests.swift
+++ b/Tests/SwifletTests/SwifletTests.swift
@@ -6,6 +6,12 @@ class SwifletTests: XCTestCase {
         let foo = Foo(bar: 2, baz: 3.0, qux: "xyz")
         let (bar, qux) = foo => { ($0.bar, $0.qux) }
         
+        do {
+            try foo => { try throwable($0) }
+        } catch {
+            XCTFail()
+        }
+        
         XCTAssertEqual(bar, 2)
         XCTAssertEqual(qux, "xyz")
     }
@@ -21,4 +27,7 @@ struct Foo {
     var bar: Int
     var baz: Float
     var qux: String
+}
+
+func throwable(_ foo: Foo) throws {
 }

--- a/Tests/SwifletTests/SwifletTests.swift
+++ b/Tests/SwifletTests/SwifletTests.swift
@@ -10,7 +10,6 @@ class SwifletTests: XCTestCase {
         XCTAssertEqual(qux, "xyz")
     }
 
-
     static var allTests : [(String, (SwifletTests) -> () throws -> Void)] {
         return [
             ("testExample", testExample),


### PR DESCRIPTION
```swift
do {
    try foo => { try throwable($0) }
} catch {
    XCTFail()
}
```